### PR TITLE
fix(gui.windows): fix shortcut not created

### DIFF
--- a/src/antares_web_installer/app.py
+++ b/src/antares_web_installer/app.py
@@ -153,6 +153,7 @@ class App:
             logger.info("No existing files found. Starting file copy...")
             copytree(self.source_dir, self.target_dir, dirs_exist_ok=True)
             logger.info("Files was successfully copied.")
+            self.version = self.check_version()
             self.update_progress(100)
 
     def copy_files(self):

--- a/src/antares_web_installer/app.py
+++ b/src/antares_web_installer/app.py
@@ -222,8 +222,8 @@ class App:
         desktop_path = Path(get_desktop())
 
         logger.info("Generating server shortcut on desktop...")
-        shortcut_name, shortcut_ext = SHORTCUT_NAMES[os.name].split('.')
-        new_shortcut_name = f"{shortcut_name}-{self.version}.{shortcut_ext}"
+        name, ext = SHORTCUT_NAMES[os.name].split('.')
+        new_shortcut_name = f"{name}-{self.version}.{ext}"
         shortcut_path = desktop_path.joinpath(new_shortcut_name)
 
         # if the shortcut already exists, remove it

--- a/src/antares_web_installer/app.py
+++ b/src/antares_web_installer/app.py
@@ -222,7 +222,7 @@ class App:
         desktop_path = Path(get_desktop())
 
         logger.info("Generating server shortcut on desktop...")
-        name, ext = SHORTCUT_NAMES[os.name].split('.')
+        name, ext = SHORTCUT_NAMES[os.name].split(".")
         new_shortcut_name = f"{name}-{self.version}.{ext}"
         shortcut_path = desktop_path.joinpath(new_shortcut_name)
 
@@ -294,7 +294,7 @@ class App:
                 if nb_attempts == max_attempts:
                     try:
                         httpx.get("http://localhost:8080/", timeout=1)
-                    except httpx.ConnectTimeout:
+                    except httpx.ConnectTimeout as e:
                         logger.error("Impossible to launch Antares Web Server after {nb_attempts} attempts.")
                         raise InstallError(f"Impossible to launch Antares Web Server after {nb_attempts} attempts: {e}")
                 time.sleep(5)

--- a/src/antares_web_installer/app.py
+++ b/src/antares_web_installer/app.py
@@ -10,10 +10,11 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from shutil import copy2, copytree
 
+import httpx
+
 if os.name == "nt":
     from pythoncom import com_error
 
-import httpx
 import psutil
 
 from antares_web_installer import logger
@@ -28,6 +29,8 @@ EXCLUDED_FILES = POSIX_EXCLUDED_FILES if os.name == "posix" else WINDOWS_EXCLUDE
 
 SERVER_NAMES = {"posix": "AntaresWebServer", "nt": "AntaresWebServer.exe"}
 SHORTCUT_NAMES = {"posix": "AntaresWebServer.desktop", "nt": "AntaresWebServer.lnk"}
+
+SERVER_ADDRESS = "http://127.0.0.1:8080"
 
 
 class InstallError(Exception):
@@ -46,8 +49,8 @@ class App:
     server_path: Path = dataclasses.field(init=False)
     progress: float = dataclasses.field(init=False)
     nb_steps: int = dataclasses.field(init=False)
-    completed_step: int = dataclasses.field(init=False)
     version: str = dataclasses.field(init=False)
+
 
     def __post_init__(self):
         # Prepare the path to the executable which is located in the target directory
@@ -75,10 +78,14 @@ class App:
             self.current_step += 1
 
         if self.launch:
-            self.start_server()
-            self.current_step += 1
-            self.open_browser()
-            self.current_step += 1
+            try:
+                self.start_server()
+            except InstallError as e:
+                raise e
+            else:
+                self.current_step += 1
+                self.open_browser()
+                self.current_step += 1
 
     def update_progress(self, progress: float):
         self.progress = (progress / self.nb_steps) + (self.current_step / self.nb_steps) * 100
@@ -96,6 +103,9 @@ class App:
             # evaluate matching between query process name and existing process name
             try:
                 matching_ratio = SequenceMatcher(None, "antareswebserver", proc.name().lower()).ratio()
+            except FileNotFoundError:
+                logger.warning("The process '{}' does not exist anymore. Skipping its analysis".format(proc.name()))
+                continue
             except psutil.NoSuchProcess:
                 logger.warning("The process '{}' was stopped before being analyzed. Skipping.".format(proc.name()))
                 continue
@@ -222,7 +232,7 @@ class App:
         desktop_path = Path(get_desktop())
 
         logger.info("Generating server shortcut on desktop...")
-        name, ext = SHORTCUT_NAMES[os.name].split(".")
+        name, ext = SHORTCUT_NAMES[os.name].split('.')
         new_shortcut_name = f"{name}-{self.version}.{ext}"
         shortcut_path = desktop_path.joinpath(new_shortcut_name)
 
@@ -255,60 +265,58 @@ class App:
         """
         Launch the local server as a background task
         """
-        logger.info("Attempt to start the newly installed server...")
-        args = [str(self.server_path)]
+        logger.info(f"Attempt to start the newly installed server located in '{self.target_dir}'...")
+        logger.debug(f"User permissions: {os.path.exists(self.server_path) and os.access(self.server_path, os.X_OK)}")
+
+        args = [self.server_path]
         server_process = subprocess.Popen(
             args=args,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            shell=True,
             cwd=self.target_dir,
+            shell=True,
         )
         self.update_progress(50)
 
         if not server_process.poll():
             logger.info("Server is starting up ...")
         else:
-            logger.info(f"The server unexpectedly stopped running. (code {server_process.returncode})")
+            stdout, stderr = server_process.communicate()
+            msg = f"The server unexpectedly stopped running. (code {server_process.returncode})"
+            logger.info(msg)
+            logger.info(f"Server unexpectedly stopped.\nstdout: {stdout}\nstderr: {stderr}")
+            raise InstallError(msg)
 
         nb_attempts = 0
-        max_attempts = 5
+        max_attempts = 10
 
         while nb_attempts < max_attempts:
-            attempt_info = f"Attempt #{nb_attempts}: "
+            logger.info(f"Attempt #{nb_attempts}...")
             try:
-                res = httpx.get("http://localhost:8080/", timeout=1)
-            except httpx.ConnectError:
-                logger.info(attempt_info + "The server is not accepting request yet. Retry ...")
-            except httpx.ConnectTimeout:
-                logger.info(attempt_info + "The server cannot retrieve a response yet. Retry ...")
-            else:
-                if res.status_code:
-                    logger.info("Server is now available.")
-                    self.update_progress(100)
-                    logger.debug("Update progress was called.")
+                res = httpx.get(SERVER_ADDRESS + "/health", timeout=1)
+                if res.status_code == 200:
+                    logger.info("The server is now running.")
                     break
-            finally:
-                nb_attempts += 1
-                if nb_attempts == max_attempts:
-                    try:
-                        httpx.get("http://localhost:8080/", timeout=1)
-                    except httpx.ConnectTimeout as e:
-                        logger.error("Impossible to launch Antares Web Server after {nb_attempts} attempts.")
-                        raise InstallError(f"Impossible to launch Antares Web Server after {nb_attempts} attempts: {e}")
-                time.sleep(5)
+            except httpx.RequestError:
+                time.sleep(1)
+            nb_attempts += 1
+        else:
+            stdout, stderr = server_process.communicate()
+            msg = "The server didn't start in time"
+            logger.error(msg)
+            logger.error(f"stdout: {stdout}\nstderr: {stderr}")
+            raise InstallError(msg)
 
     def open_browser(self):
         """
         Open server URL in default user's browser
         """
         logger.debug("In open browser method.")
-        url = "http://localhost:8080/"
         try:
-            webbrowser.open(url=url, new=2)
+            webbrowser.open(url=SERVER_ADDRESS, new=2)
         except webbrowser.Error as e:
-            raise InstallError(f"Could not open browser at '{url}': {e}") from e
+            raise InstallError(f"Could not open browser at '{SERVER_ADDRESS}': {e}") from e
         else:
             logger.info("Browser was successfully opened.")
         self.update_progress(100)

--- a/src/antares_web_installer/app.py
+++ b/src/antares_web_installer/app.py
@@ -51,7 +51,6 @@ class App:
     nb_steps: int = dataclasses.field(init=False)
     version: str = dataclasses.field(init=False)
 
-
     def __post_init__(self):
         # Prepare the path to the executable which is located in the target directory
         server_name = SERVER_NAMES[os.name]
@@ -232,7 +231,7 @@ class App:
         desktop_path = Path(get_desktop())
 
         logger.info("Generating server shortcut on desktop...")
-        name, ext = SHORTCUT_NAMES[os.name].split('.')
+        name, ext = SHORTCUT_NAMES[os.name].split(".")
         new_shortcut_name = f"{name}-{self.version}.{ext}"
         shortcut_path = desktop_path.joinpath(new_shortcut_name)
 

--- a/src/antares_web_installer/gui/controller.py
+++ b/src/antares_web_installer/gui/controller.py
@@ -91,7 +91,7 @@ class WizardController(Controller):
     # initialize file handler logger
     def init_console_handler(self, callback):
         """
-        
+
         @param callback:
         @return:
         """
@@ -117,8 +117,8 @@ class WizardController(Controller):
 
     def install(self, callback: typing.Callable):
         """
-            Run App.install method
-            @param callback: function that is used to update logs
+        Run App.install method
+        @param callback: function that is used to update logs
         """
         self.init_log_file_handler()
         self.logger.debug("file logger initialized.")

--- a/src/antares_web_installer/gui/controller.py
+++ b/src/antares_web_installer/gui/controller.py
@@ -90,18 +90,36 @@ class WizardController(Controller):
 
     # initialize file handler logger
     def init_console_handler(self, callback):
+        """
+        
+        @param callback:
+        @return:
+        """
         console_handler = ConsoleHandler(callback)
         self.logger.addHandler(console_handler)
 
     def init_progress_handler(self, callback):
+        """
+        Initialize handler log of progress.
+        The logs generated will be shown on the window console during installation
+        @param callback: function that is used to update logs
+        """
         progress_logger = ProgressHandler(callback)
         self.logger.addHandler(progress_logger)
 
     def run(self) -> None:
+        """
+        start program
+        @return:
+        """
         self.view.update_view()
         super().run()
 
     def install(self, callback: typing.Callable):
+        """
+            Run App.install method
+            @param callback: function that is used to update logs
+        """
         self.init_log_file_handler()
         self.logger.debug("file logger initialized.")
         self.init_console_handler(callback)

--- a/src/antares_web_installer/gui/widgets/frame.py
+++ b/src/antares_web_installer/gui/widgets/frame.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from antares_web_installer.shortcuts import get_homedir
 from .button import CancelBtn, BackBtn, NextBtn, FinishBtn, InstallBtn
+from ..mvc import ControllerError
 
 if TYPE_CHECKING:
     from antares_web_installer.gui.view import WizardView
@@ -152,8 +153,12 @@ class PathChoicesFrame(BasicFrame):
             title="Choose the target directory",
             initialdir=get_homedir(),
         )
-        self.window.set_target_dir(dir_path)
-        self.target_path.set(dir_path)
+        try:
+            self.window.set_target_dir(dir_path)
+        except ControllerError:
+            pass
+        else:
+            self.target_path.set(dir_path)
 
     def get_next_frame(self):
         # Lazy import for typing and testing purposes

--- a/src/antares_web_installer/shortcuts/_win32_shell.py
+++ b/src/antares_web_installer/shortcuts/_win32_shell.py
@@ -56,14 +56,6 @@ def create_shortcut(
     if isinstance(arguments, str):
         arguments = [arguments] if arguments else []
 
-    target_parent, target_name = str(target).rsplit("\\", maxsplit=1)
-    new_target_name = "Antares Web Server.lnk"
-    new_target = os.path.join(target_parent, new_target_name)
-
-    # remove any existing shortcut
-    if os.path.exists(new_target):
-        os.remove(new_target)
-
     wscript = _WSHELL.CreateShortCut(str(target))
     wscript.TargetPath = str(exe_path)
     wscript.Arguments = " ".join(arguments)
@@ -74,6 +66,3 @@ def create_shortcut(
     if icon_path:
         wscript.IconLocation = str(icon_path)
     wscript.save()
-
-    # add spaces to shortcut name
-    os.rename(target, new_target)

--- a/tests/integration/server_mock/web.py
+++ b/tests/integration/server_mock/web.py
@@ -26,7 +26,6 @@ async def lifespan(_unused_app: FastAPI) -> t.AsyncGenerator[None, None]:
     asyncio.create_task(stop_server())
     yield
 
-
 app = FastAPI(lifespan=lifespan)
 
 

--- a/tests/integration/server_mock/web.py
+++ b/tests/integration/server_mock/web.py
@@ -26,6 +26,7 @@ async def lifespan(_unused_app: FastAPI) -> t.AsyncGenerator[None, None]:
     asyncio.create_task(stop_server())
     yield
 
+
 app = FastAPI(lifespan=lifespan)
 
 

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -108,7 +108,14 @@ class TestApp:
         """
         for source_dir in downloaded_dir.iterdir():
             # Run the application
-            app = App(source_dir=source_dir, target_dir=program_dir, shortcut=False, launch=True)
+            # Make sure each application is installed in new directory
+            custom_dir = program_dir.joinpath(source_dir.name)
+            app = App(
+                source_dir=source_dir,
+                target_dir=custom_dir,
+                shortcut=False,
+                launch=True
+            )
             try:
                 app.run()
             except InstallError:
@@ -116,11 +123,11 @@ class TestApp:
                 raise
 
             # check if application was successfully installed in the target dir (program_dir)
-            assert program_dir.is_dir()
-            assert program_dir.iterdir()
+            assert custom_dir.is_dir()
+            assert custom_dir.iterdir()
 
             # check if all files are identical in both source_dir (application_dir) and target_dir (program_dir)
-            program_dir_content = list(program_dir.iterdir())
+            program_dir_content = list(custom_dir.iterdir())
             source_dir_content = list(source_dir.iterdir())
             assert len(source_dir_content) == len(program_dir_content)
             for index, file in enumerate(source_dir.iterdir()):
@@ -128,15 +135,6 @@ class TestApp:
 
             # give some time for the server to shut down
             time.sleep(2)
-
-            # remove all files before installing the other versions
-            for file in program_dir.iterdir():
-                if file.is_dir():
-                    shutil.rmtree(file)
-                else:
-                    os.remove(file)
-            program_dir_content = list(program_dir.iterdir())
-            assert len(program_dir_content) == 0
 
     def test_shortcut__created(self, downloaded_dir: Path, program_dir: Path, desktop_dir: Path, settings: Any):
         for application_dir in downloaded_dir.iterdir():

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -110,12 +110,7 @@ class TestApp:
             # Run the application
             # Make sure each application is installed in new directory
             custom_dir = program_dir.joinpath(source_dir.name)
-            app = App(
-                source_dir=source_dir,
-                target_dir=custom_dir,
-                shortcut=False,
-                launch=True
-            )
+            app = App(source_dir=source_dir, target_dir=custom_dir, shortcut=False, launch=True)
             try:
                 app.run()
             except InstallError:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,8 @@
 import hashlib
 from pathlib import Path
+
+import pytest
+
 from antares_web_installer.app import App, EXCLUDED_FILES
 
 
@@ -13,7 +16,7 @@ class TestApp:
         # 3. Vérifier que le serveur a bien été tué
         pass
 
-    def test_install_files__from_scratch(self, tmp_path: Path) -> None:
+    def test_install_files__from_scratch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """
         Case where the target directory does not exist.
         """
@@ -21,6 +24,7 @@ class TestApp:
         source_dir = tmp_path / "source"
         source_dir.mkdir()
         target_dir = tmp_path / "target"
+        monkeypatch.setattr("antares_web_installer.app.App.check_version", lambda _: "2.17.0")
 
         # Say we have dummy files in the source directory
         expected_files = ["dummy.txt", "folder/dummy2.txt"]


### PR DESCRIPTION
* On Windows, when a shortcut must be created, the shortcut was not generated because of a bug occuring when the name of the shortcut was built.

* The new package AntaREST is built with another zip file. The installer must ignore this file from the copy-able file in order to avoid potential bugs.

* Add the version name in the shortcut name.