### PR TITLE
Logger process does not respond during the installation

### DIFF
--- a/src/antares_web_installer/app.py
+++ b/src/antares_web_installer/app.py
@@ -112,15 +112,17 @@ class App:
             if matching_ratio > 0.8:
                 logger.info("Running server found. Attempt to stop it ...")
                 logger.debug(f"Server process:{proc.name()} -  process id: {proc.pid}")
-                running_app = psutil.Process(pid=proc.pid)
-                running_app.kill()
-
                 try:
+                    running_app = psutil.Process(pid=proc.pid)
+                    running_app.kill()
                     running_app.wait(5)
                 except psutil.TimeoutExpired as e:
                     raise InstallError(
                         "Impossible to kill the server. Please kill it manually before relaunching the installer."
                     ) from e
+                except psutil.NoSuchProcess:
+                    logger.warning("The process '{}' was stopped before being analyzed. Skipping.".format(proc.name()))
+                    continue
                 else:
                     logger.info("The application was successfully stopped.")
             self.update_progress((index + 1) * 100 / processes_list_length)

--- a/src/antares_web_installer/app.py
+++ b/src/antares_web_installer/app.py
@@ -89,6 +89,7 @@ class App:
     def update_progress(self, progress: float):
         self.progress = (progress / self.nb_steps) + (self.current_step / self.nb_steps) * 100
         logger.info(f"Progression: {self.progress:.2f}")
+        time.sleep(0.5)
 
     def kill_running_server(self) -> None:
         """
@@ -288,7 +289,7 @@ class App:
             raise InstallError(msg)
 
         nb_attempts = 0
-        max_attempts = 10
+        max_attempts = 30
 
         while nb_attempts < max_attempts:
             logger.info(f"Attempt #{nb_attempts}...")
@@ -311,6 +312,7 @@ class App:
         """
         Open server URL in default user's browser
         """
+        time.sleep(1)
         logger.debug("In open browser method.")
         try:
             webbrowser.open(url=SERVER_ADDRESS, new=2)

--- a/src/antares_web_installer/gui/controller.py
+++ b/src/antares_web_installer/gui/controller.py
@@ -64,7 +64,7 @@ class WizardController(Controller):
         return WizardView(self)
 
     def init_file_handler(self):
-        self.log_dir = self.model.target_dir.joinpath("logs/")
+        self.log_dir = self.model.source_dir.joinpath("logs/")
         tmp_file_name = "wizard.log"
 
         if not self.log_dir.exists():
@@ -200,3 +200,5 @@ class WizardController(Controller):
                     logger.debug("Error while moving log file: {}".format(e))
             except PermissionError as e:
                 logger.debug("Impossible to move log file: {}".format(e))
+            except OSError as e:
+                logger.debug("Disk Error while attempting to move log file: ".format(e))

--- a/src/antares_web_installer/gui/controller.py
+++ b/src/antares_web_installer/gui/controller.py
@@ -200,5 +200,5 @@ class WizardController(Controller):
                     logger.debug("Error while moving log file: {}".format(e))
             except PermissionError as e:
                 logger.debug("Impossible to move log file: {}".format(e))
-            except OSError as e:
-                logger.debug("Disk Error while attempting to move log file: ".format(e))
+            except OSError:
+                logger.debug("Disk Error while attempting to move log file: ".format())


### PR DESCRIPTION
This pull request must fix the following bugs:
- The logger process kept crashing when attempting to spawn the already installed server
- The chosen target path was not updated after the user selected one
- The newly installed server weren't able to retrieve a response in time when launched at the end of the process 