### PR TITLE
fix: fix installing to wrong directory

### DIFF
--- a/src/antares_web_installer/gui/controller.py
+++ b/src/antares_web_installer/gui/controller.py
@@ -2,7 +2,7 @@
 references:
 ebarr: https://stackoverflow.com/questions/23947281/python-multiprocessing-redirect-stdout-of-a-child-process-to-a-tkinter-text
 """
-
+import shutil
 import typing
 from pathlib import Path
 from threading import Thread
@@ -176,7 +176,7 @@ class WizardController(Controller):
             # move log file into Antares logs directory
             new_log_file_path = self.get_target_dir().joinpath(self.log_file.parent.name, self.log_file.name)
             try:
-                self.log_file.replace(new_log_file_path)
+                shutil.move(str(self.log_file), str(new_log_file_path))
             except FileNotFoundError as e:
                 if new_log_file_path.exists():
                     logger.debug("Log file '{}' was already moved. Skip renaming step.".format(new_log_file_path))

--- a/src/antares_web_installer/gui/controller.py
+++ b/src/antares_web_installer/gui/controller.py
@@ -2,6 +2,7 @@
 references:
 ebarr: https://stackoverflow.com/questions/23947281/python-multiprocessing-redirect-stdout-of-a-child-process-to-a-tkinter-text
 """
+
 import shutil
 import typing
 from pathlib import Path

--- a/src/antares_web_installer/gui/model.py
+++ b/src/antares_web_installer/gui/model.py
@@ -28,18 +28,8 @@ class WizardModel(Model):
         self.shortcut = True
         self.launch = True
 
-    def set_target_dir(self, new_target_dir: Path) -> bool:
-        """
-        Return False if target does not exist, True otherwise
-        @param new_target_dir:
-        @return:
-        """
-        if not self.target_dir.exists():
-            logger.error("Target directory '{}' does not exist.".format(self.target_dir))
-            return False
-        else:
-            self.target_dir = new_target_dir
-            return True
+    def set_target_dir(self, new_target_dir: Path) -> None:
+        self.target_dir = new_target_dir
 
     def set_shortcut(self, new_shortcut: bool):
         self.shortcut = new_shortcut

--- a/src/antares_web_installer/gui/mvc.py
+++ b/src/antares_web_installer/gui/mvc.py
@@ -44,10 +44,6 @@ class View(tk.Tk):
         messagebox.showerror("Exception", "".join(err))
 
 
-class ControllerError(Exception):
-    pass
-
-
 class Controller:
     """
     Base class of the MVC controller.

--- a/src/antares_web_installer/gui/view.py
+++ b/src/antares_web_installer/gui/view.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from tkinter import ttk, font
 from tkinter.messagebox import showerror, showwarning
 
-from antares_web_installer.gui.mvc import View, ControllerError, ViewError
+from antares_web_installer.gui.mvc import View, ViewError
 from antares_web_installer.gui.widgets.frame import (
     WelcomeFrame,
     PathChoicesFrame,
@@ -172,13 +172,7 @@ class WizardView(View):
             raise ViewError("Controller is not a WizardController")
 
     def update_log_file(self):
-        try:
-            self.controller.update_log_file()
-        except ControllerError:
-            self.raise_error(
-                "The application was successfully installed although a minor error occurred. You may "
-                "continue or close the installer."
-            )
+        self.controller.update_log_file()
 
     def run_installation(self, callback):
         self.controller.install(callback)

--- a/src/antares_web_installer/gui/widgets/frame.py
+++ b/src/antares_web_installer/gui/widgets/frame.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 from antares_web_installer.shortcuts import get_homedir
 from .button import CancelBtn, BackBtn, NextBtn, FinishBtn, InstallBtn
-from ..mvc import ControllerError
 
 if TYPE_CHECKING:
     from antares_web_installer.gui.view import WizardView
@@ -153,12 +152,8 @@ class PathChoicesFrame(BasicFrame):
             title="Choose the target directory",
             initialdir=get_homedir(),
         )
-        try:
-            self.window.set_target_dir(dir_path)
-        except ControllerError:
-            pass
-        else:
-            self.target_path.set(dir_path)
+        self.window.set_target_dir(dir_path)
+        self.target_path.set(dir_path)
 
     def get_next_frame(self):
         # Lazy import for typing and testing purposes


### PR DESCRIPTION

When the default target directory did not exist, we ended up 
installing to it, instead of the one selected by the user.