### PR TITLE
feature(config): set desktop mode flag to true in config file

### DIFF
--- a/src/antares_web_installer/config/__init__.py
+++ b/src/antares_web_installer/config/__init__.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import yaml
 
 from antares_web_installer.config.config_2_19 import update_to_2_19
+from antares_web_installer.config.config_desktop import update_for_desktop
 
 
 def update_config(source_path: Path, target_config_path: Path, version: str) -> None:
@@ -24,6 +25,8 @@ def update_config(source_path: Path, target_config_path: Path, version: str) -> 
     version_info = tuple(map(int, version.split(".")))
     if version_info < (2, 19):
         update_to_2_19(config)
+
+    update_for_desktop(config)
 
     with target_config_path.open(mode="w") as f:
         yaml.dump(config, f)

--- a/src/antares_web_installer/config/config_desktop.py
+++ b/src/antares_web_installer/config/config_desktop.py
@@ -1,0 +1,10 @@
+import typing as t
+
+
+def update_for_desktop(config: t.MutableMapping[str, t.Any]) -> None:
+    """
+    Force desktop_mode to true in config file.
+
+    :param config: actual configuration
+    """
+    config["desktop_mode"] = True


### PR DESCRIPTION
Related to this ticket https://gopro-tickets.rte-france.com/browse/ANT-2844

Now desktop build must have a flag "desktop_mode" set to true in the config file. 

It already is by default, this PR will update existing installations. 

