### PR TITLE
feature(workspaces): remove workspaces from config other than default workspace

### DIFF
--- a/src/antares_web_installer/config/config_desktop.py
+++ b/src/antares_web_installer/config/config_desktop.py
@@ -14,11 +14,9 @@ def update_for_desktop(config: t.MutableMapping[str, t.Any]) -> None:
     config["desktop_mode"] = True
 
     if "storage" not in config:
-        logger.error("storage missing in config file ", config)
-        return
+        raise ValueError("storage missing in config file ", config)
     if "workspaces" not in config["storage"]:
-        logger.error("workspaces missing in storage config ", config["storage"])
-        return
+        raise ValueError("workspaces missing in storage config ", config["storage"])
     workspaces = config["storage"]["workspaces"]
 
     keys_to_remove = [key for key in workspaces if key != "default"]

--- a/src/antares_web_installer/config/config_desktop.py
+++ b/src/antares_web_installer/config/config_desktop.py
@@ -1,10 +1,28 @@
 import typing as t
 
+from antares_web_installer import logger
+
+
 
 def update_for_desktop(config: t.MutableMapping[str, t.Any]) -> None:
     """
     Force desktop_mode to true in config file.
 
+    Rmove workspaces other than default workspace.  
+
     :param config: actual configuration
     """
     config["desktop_mode"] = True
+
+    if "storage" not in config:
+        logger.error("storage missing in config file ", config)
+        return
+    if "workspaces" not in config["storage"]:
+        logger.error("storage missing in config file ", config)
+        return
+    
+    workspaces = config["storage"]["workspaces"]
+
+    keys_to_remove = [key for key in workspaces if key != "default"]
+    for key in keys_to_remove:
+        del workspaces[key]

--- a/src/antares_web_installer/config/config_desktop.py
+++ b/src/antares_web_installer/config/config_desktop.py
@@ -1,7 +1,5 @@
 import typing as t
 
-from antares_web_installer import logger
-
 
 def update_for_desktop(config: t.MutableMapping[str, t.Any]) -> None:
     """

--- a/src/antares_web_installer/config/config_desktop.py
+++ b/src/antares_web_installer/config/config_desktop.py
@@ -3,12 +3,11 @@ import typing as t
 from antares_web_installer import logger
 
 
-
 def update_for_desktop(config: t.MutableMapping[str, t.Any]) -> None:
     """
     Force desktop_mode to true in config file.
 
-    Rmove workspaces other than default workspace.  
+    Remove workspaces other than default workspace.
 
     :param config: actual configuration
     """
@@ -20,7 +19,6 @@ def update_for_desktop(config: t.MutableMapping[str, t.Any]) -> None:
     if "workspaces" not in config["storage"]:
         logger.error("workspaces missing in storage config ", config["storage"])
         return
-    
     workspaces = config["storage"]["workspaces"]
 
     keys_to_remove = [key for key in workspaces if key != "default"]

--- a/src/antares_web_installer/config/config_desktop.py
+++ b/src/antares_web_installer/config/config_desktop.py
@@ -18,7 +18,7 @@ def update_for_desktop(config: t.MutableMapping[str, t.Any]) -> None:
         logger.error("storage missing in config file ", config)
         return
     if "workspaces" not in config["storage"]:
-        logger.error("storage missing in config file ", config)
+        logger.error("workspaces missing in storage config ", config["storage"])
         return
     
     workspaces = config["storage"]["workspaces"]


### PR DESCRIPTION
I'm not sure this is usefull to enforce the config like this. As in Antarest the default value are already set correctly in resources/antares-desktop-fs/config.yaml. Also the Antarest app will fail to start if other workspaces are configured. 